### PR TITLE
[FEAT] axios 인스턴스 수정 및 private 추가

### DIFF
--- a/src/components/private.tsx
+++ b/src/components/private.tsx
@@ -1,0 +1,27 @@
+import { useNavigate } from "react-router-dom";
+import { Lock } from "lucide-react";
+
+export default function Private({ children }: { children: React.ReactNode }) {
+  const token = localStorage.getItem("authToken");
+  const navigate = useNavigate();
+
+  if (!token) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-40 text-gray-300">
+        <Lock className="h-16 w-16 text-pink-300" />
+        <p className="text-[20px] font-bold text-gray-500">
+          로그인이 필요한 페이지입니다
+        </p>
+        <p className="text-[15px]">로그인 후 이용해주세요</p>
+        <button
+          onClick={() => navigate("/login")}
+          className="rounded-2xl bg-pink-500 px-8 py-3 text-white font-semibold hover:bg-pink-400 transition-colors"
+        >
+          로그인하러 가기
+        </button>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -4,4 +4,28 @@ const instance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
+// 요청 - 토큰 자동 첨부
+instance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("authToken");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+// 응답 - 401 처리
+instance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem("authToken");
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  },
+);
+
 export default instance;


### PR DESCRIPTION
## 🎯 작업 내용
`src/lib/axios.ts` axios 인스턴스 생성 및 인터셉터 설정 
`src/components/private` 로그인 여부에 따른 페이지 접근 제어 

## 📝 변경 사항
- `src/components/private` : 비 로그인 사용자가 로그인이 필요한 페이지를 방문했을 경우를 대비하여 추가함
- `src/lib/axios.ts` : 토큰을 추가하도록 수정
  - 요청 인터셉터: 모든 API 요청에 `localStorage`의 `authToken`을 `Authorization: Bearer` 헤더에 자동 첨부
  - 응답 인터셉터: 401 응답 시 토큰 삭제 후 `/login`으로 자동 리다이렉트


## 🔗 관련 이슈
Close #

## ✅ 체크리스트
- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 불필요한 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)
<img width="3378" height="1818" alt="image" src="https://github.com/user-attachments/assets/4b2de310-2290-4e2b-baab-a8d8ee465d2b" />


