### PR TITLE
[FEAT] 관리자 상품 목록 페이지 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import ProductDetailPage from "./pages/product/ProductDetailPage";
 import OrderPage from "./pages/order/OrderPage";
 import OrderCompletePage from "./pages/order/OrderCompletePage";
 import CartPage from "./pages/CartPage";
-import ManagePage from "./pages/AdminProductPage";
+import ManagePage from "./pages/admin/AdminProductPage";
 import MyPage from "./pages/MyPage";
 import Private from "./components/private";
 import ProductCreatePage from "./pages/admin/ProductCreatePage";

--- a/src/api/product.api.ts
+++ b/src/api/product.api.ts
@@ -3,11 +3,12 @@ import {
   Product,
   ProductFormData,
   BackendProductResponse,
+  ProductStatus,
 } from "@/types/product";
 import { MOCK_PRODUCTS, getProductById } from "@/mocks/data/products";
 
 // Mock 모드 (백엔드 준비되면 false로 변경)
-const USE_MOCK = true;
+const USE_MOCK = false;
 
 const mockDelay = (ms = 500): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -124,6 +125,51 @@ export const getProducts = async (
   } else {
     return fetchProductsFromAPI(page, sortBy);
   }
+};
+
+export const getAdminProducts = async (
+  page: number = 1,
+  status: string = "ALL",
+  keyword: string = "",
+): Promise<GetProductsResponse> => {
+  if (USE_MOCK) {
+    return { products: MOCK_PRODUCTS, totalPages: 1 }; // 임시(목데이터용)
+  }
+
+  const apiStatus = status === "ALL" ? undefined : status;
+  const search = keyword.trim() === "" ? undefined : keyword;
+
+  const response = await instance.get("/api/v1/admin/products", {
+    params: {
+      page,
+      limit: 5,
+      status: apiStatus,
+      search: search,
+    },
+  });
+
+  const products: Product[] = response.data.data.products.map(
+    (item: BackendProductResponse): Product => ({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      currentPrice: item.price,
+      originalPrice: item.price, // 임시
+      discountRate: 0, // 임시
+      rating: 0, // 임시
+      reviewCount: 0, // 임시
+      stock: item.stock,
+      shippingFee: 3000,
+      freeShippingThreshold: 50000,
+      imageUrl: item.image_url,
+      status: item.product_status as ProductStatus, // 백엔드 string을 프론트 타입으로 단언
+    }),
+  );
+
+  return {
+    products,
+    totalPages: response.data.data.pagination.total_pages,
+  };
 };
 
 // 상품 등록

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -7,7 +7,7 @@ const instance = axios.create({
 // 요청 - 토큰 자동 첨부
 instance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("authToken");
+    const token = localStorage.getItem("accessToken");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -32,7 +32,7 @@ instance.interceptors.response.use(
 
         const { data } = await axios.post(
           `${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/refresh`,
-          { refresh_token: refreshToken }
+          { refresh_token: refreshToken },
         );
 
         if (data.success && data.data) {
@@ -49,7 +49,7 @@ instance.interceptors.response.use(
       } catch (refreshError) {
         localStorage.removeItem("authToken");
         localStorage.removeItem("refreshToken");
-        window.location.href = "/login"
+        window.location.href = "/login";
         return Promise.reject(refreshError);
       }
     }

--- a/src/mocks/data/products.ts
+++ b/src/mocks/data/products.ts
@@ -223,7 +223,7 @@ export const MOCK_PRODUCTS: Product[] = [
     freeShippingThreshold: 100000,
     imageUrl:
       "https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=500",
-    status: "DELETED",
+    status: "INACTIVE",
   },
   {
     id: 15,

--- a/src/pages/admin/AdminProductPage.tsx
+++ b/src/pages/admin/AdminProductPage.tsx
@@ -1,43 +1,59 @@
-import { useState, useMemo } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from 'react-router-dom';
 import { useQueryState, parseAsInteger, parseAsString } from 'nuqs';
 import { AdminItemList } from "@/components/admin/adminItemList";
-import { MOCK_PRODUCTS } from "@/mocks/data/products";
-import { STATUS_CONFIG, ProductStatus } from "@/types/product";
+import { STATUS_CONFIG, ProductStatus, Product } from "@/types/product";
+import { getAdminProducts } from "@/api/product.api";
 import { BadgePlus, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Pagination } from "@/components/pagination";
 import { StateFilter } from "@/components/admin/stateFilter";
+import { Loading } from "@/components/loading";
 
 const FILTER_STATES = [
     { id: "ALL", label: "전체 상태" },
     ...(Object.entries(STATUS_CONFIG).map(([key, value]) => ({ id: key as ProductStatus, label: value.label, })))
 ]
 function AdminProductPage() {
+    const navigate = useNavigate();
     const [currentPage, setCurrentPage] = useQueryState("page", parseAsInteger.withDefault(1));
     const [selectedFilterId, setSelectedFilterId] = useQueryState("status", parseAsString.withDefault("ALL"));
     const [activeSearchWord, setActiveSearchWord] = useQueryState("keyword", parseAsString.withDefault(""));
     const [searchWord, setSearchWord] = useState(activeSearchWord);
-    const itemsPerPage = 5;
+
+    const [products, setProducts] = useState<Product[]>([]);
+    const [totalPages, setTotalPages] = useState(1);
+    const [loading, setLoading] = useState(true);
 
     const handleSearch = () => {
         setActiveSearchWord(searchWord);
         setCurrentPage(1);
     };
 
-    const filteredItems = useMemo(() => {
-        return MOCK_PRODUCTS.filter(item => {
-            const matchesStatus = selectedFilterId === "ALL" || item.status === selectedFilterId; // 상태
-            const matchesSearch = item.name.toLowerCase().includes(activeSearchWord.toLowerCase()); // 검색어
-            return matchesStatus && matchesSearch;
-        });
-    }, [selectedFilterId, activeSearchWord]);
+    useEffect(() => {
+        const fetchAdminData = async () => {
+            setLoading(true);
+            try {
+                const response = await getAdminProducts(currentPage, selectedFilterId, activeSearchWord);
+                setProducts(response.products);
+                setTotalPages(response.totalPages);
+            } catch (error) {
+                console.error("관리자 상품 목록을 불러오지 못했습니다.", error);
+            } finally {
+                setLoading(false);
+            }
+        };
 
-    const totalPages = Math.ceil(filteredItems.length / itemsPerPage);
+        fetchAdminData();
+    }, [currentPage, selectedFilterId, activeSearchWord]);
 
-    const currentDisplayItems = useMemo(() => {
-        const start = (currentPage - 1) * itemsPerPage;
-        return filteredItems.slice(start, start + itemsPerPage);
-    }, [filteredItems, currentPage]);
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <Loading />
+            </div>
+        );
+    }
 
     return (
         <main className="w-full min-h-screen py-10 px-[120px]">
@@ -46,7 +62,9 @@ function AdminProductPage() {
                     <h1 className="text-[32px] font-semibold text-gray-500 ml-2 text-left">
                         상품 관리
                     </h1>
-                    <button className="flex items-center rounded-lg text-[24px] px-4 h-14 gap-2 bg-pink-500 text-primary-foreground shadow hover:bg-pink-500/80">
+                    <button
+                        onClick={() => navigate("/admin/product/new")}
+                        className="flex items-center rounded-lg text-[24px] px-4 h-14 gap-2 bg-pink-500 text-primary-foreground shadow hover:bg-pink-500/80">
                         <BadgePlus size={28} />
                         새 상품 등록
                     </button>
@@ -79,7 +97,7 @@ function AdminProductPage() {
                         }}
                     />
                 </div>
-                <AdminItemList items={currentDisplayItems} />
+                <AdminItemList items={products} />
                 <Pagination
                     currentPage={currentPage}
                     totalPages={totalPages}

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,13 +1,12 @@
-export type ProductStatus = "ACTIVE" | "INACTIVE" | "SOLD_OUT" | "DELETED";
+export type ProductStatus = "ACTIVE" | "INACTIVE" | "SOLD_OUT";
 
 export const STATUS_CONFIG: Record<
   ProductStatus,
   { label: string; className: string }
 > = {
   ACTIVE: { label: "판매 중", className: "bg-pink-500" },
-  INACTIVE: { label: "판매 중지", className: "bg-gray-300" },
+  INACTIVE: { label: "판매 중지", className: "bg-red" },
   SOLD_OUT: { label: "품절", className: "bg-gray-300" },
-  DELETED: { label: "삭제", className: "bg-red" },
 } as const;
 export interface Product {
   id: number;


### PR DESCRIPTION
## 🎯 작업 내용
관리자 상품 목록 페이지 API 연동하였습니다.
권한 오류 때문에 실제 동작 확인은 해보지 못했습니다ㅜ 추후 오류 발생시 수정하겠습니다
+ 권한 오류 해결하려 이것저것 해보면서 `axios` 파일의 토큰명을 수정하였는데 혹시 나중에 테스트해보실 때 이것때문에 오류날까봐 말씀드려요.. 참고해주세요!ㅜㅜ

## 📝 변경 사항
- `AdminProductPage.tsx` API 연동 & 경로 `src/pages/admin/` 으로 변경
- 새 상품 등록하기 버튼 클릭 시 `//admin/product/new` 으로 이동되도록 설정

## 🔗 관련 이슈
Close #

## ✅ 체크리스트
- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 불필요한 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)
```



